### PR TITLE
workflows: extend the test range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
     with:
       license-check: true
       lint: true
-      node-versions: '["14", "16", "18", "20"]'
+      node-versions: '["16", "18", "20"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v4.1.0
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v4.2.0
     with:
       license-check: true
       lint: true
+      node-versions: '["14", "16", "18", "20"]'

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@fastify/pre-commit": "^2.1.0",
     "benchmark": "2.1.4",
     "standard": "17.1.0",
-    "tap": "^18.7.0",
-    "tsd": "^0.30.7"
+    "tap": "^18.7.2",
+    "tsd": "^0.31.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We don't necessarily need to stop testing on older versions for libraries, we can just extend the test range using the new workflow