### PR TITLE
chore: migrate from tap to node:test and c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "standard index.js test/* benchmarks/*",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "c8 --100 node --test",
     "test:typescript": "tsd"
   },
   "standard": {
@@ -35,8 +35,8 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "benchmark": "2.1.4",
+    "c8": "^10.1.2",
     "standard": "17.1.2",
-    "tap": "^18.7.2",
     "tsd": "^0.31.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "license": "MIT",
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
+    "@matteo.collina/tspl": "^0.1.1",
     "benchmark": "2.1.4",
     "c8": "^10.1.2",
     "standard": "17.1.2",

--- a/test/Negotiator.test.js
+++ b/test/Negotiator.test.js
@@ -1,26 +1,26 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const testCases = require('./testCases')
 const Negotiator = require('../index').Negotiator
 
 test('should create Negotiator-Instances', t => {
   t.plan(2)
-  t.ok(new Negotiator() instanceof Negotiator)
-  t.ok(Negotiator() instanceof Negotiator)
+  t.assert.ok(new Negotiator() instanceof Negotiator)
+  t.assert.ok(Negotiator() instanceof Negotiator)
 })
 
 for (const [header, supportedEncodings, expected] of testCases) {
   test(`should return ${expected} when ${header} and ${supportedEncodings}`, t => {
     t.plan(4)
     const negotiatorNoCache = new Negotiator({ supportedValues: supportedEncodings })
-    t.equal(negotiatorNoCache.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
+    t.assert.strictEqual(negotiatorNoCache.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
 
     const negotiatorNonClass = Negotiator({ supportedValues: supportedEncodings })
-    t.equal(negotiatorNonClass.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
+    t.assert.strictEqual(negotiatorNonClass.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
 
     const negotiatorCache = new Negotiator({ supportedValues: supportedEncodings, cache: new Map() })
-    t.equal(negotiatorCache.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
-    t.equal(negotiatorCache.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
+    t.assert.strictEqual(negotiatorCache.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
+    t.assert.strictEqual(negotiatorCache.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
   })
 }

--- a/test/Negotiator.test.js
+++ b/test/Negotiator.test.js
@@ -1,26 +1,28 @@
 'use strict'
 
 const { test } = require('node:test')
+const { tspl } = require('@matteo.collina/tspl')
 const testCases = require('./testCases')
 const Negotiator = require('../index').Negotiator
 
 test('should create Negotiator-Instances', t => {
-  t.plan(2)
-  t.assert.ok(new Negotiator() instanceof Negotiator)
-  t.assert.ok(Negotiator() instanceof Negotiator)
+  const { ok } = tspl(t, { plan: 2 })
+
+  ok(new Negotiator() instanceof Negotiator)
+  ok(Negotiator() instanceof Negotiator)
 })
 
 for (const [header, supportedEncodings, expected] of testCases) {
   test(`should return ${expected} when ${header} and ${supportedEncodings}`, t => {
-    t.plan(4)
+    const { strictEqual } = tspl(t, { plan: 4 })
     const negotiatorNoCache = new Negotiator({ supportedValues: supportedEncodings })
-    t.assert.strictEqual(negotiatorNoCache.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
+    strictEqual(negotiatorNoCache.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
 
     const negotiatorNonClass = Negotiator({ supportedValues: supportedEncodings })
-    t.assert.strictEqual(negotiatorNonClass.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
+    strictEqual(negotiatorNonClass.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
 
     const negotiatorCache = new Negotiator({ supportedValues: supportedEncodings, cache: new Map() })
-    t.assert.strictEqual(negotiatorCache.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
-    t.assert.strictEqual(negotiatorCache.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
+    strictEqual(negotiatorCache.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
+    strictEqual(negotiatorCache.negotiate(header), expected, `should return ${expected} when ${header} and ${supportedEncodings}`)
   })
 }

--- a/test/negotiate.test.js
+++ b/test/negotiate.test.js
@@ -8,9 +8,6 @@ const negotiate = require('../index').negotiate
 for (const [header, supportedEncodings, expected] of testCases) {
   test(`should return ${expected} when ${header} and ${supportedEncodings}`, t => {
     const { strictEqual } = tspl(t, { plan: 1 })
-    new Promise((resolve) => {
-      strictEqual(negotiate(header, supportedEncodings), expected)
-      resolve()
-    })
+    strictEqual(negotiate(header, supportedEncodings), expected)
   })
 }

--- a/test/negotiate.test.js
+++ b/test/negotiate.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const testCases = require('./testCases')
 const negotiate = require('../index').negotiate
 
 for (const [header, supportedEncodings, expected] of testCases) {
   test(`should return ${expected} when ${header} and ${supportedEncodings}`, t => {
     t.plan(1)
-    t.equal(negotiate(header, supportedEncodings), expected)
+    t.assert.strictEqual(negotiate(header, supportedEncodings), expected)
   })
 }

--- a/test/negotiate.test.js
+++ b/test/negotiate.test.js
@@ -1,12 +1,16 @@
 'use strict'
 
 const { test } = require('node:test')
+const { tspl } = require('@matteo.collina/tspl')
 const testCases = require('./testCases')
 const negotiate = require('../index').negotiate
 
 for (const [header, supportedEncodings, expected] of testCases) {
   test(`should return ${expected} when ${header} and ${supportedEncodings}`, t => {
-    t.plan(1)
-    t.assert.strictEqual(negotiate(header, supportedEncodings), expected)
+    const { strictEqual } = tspl(t, { plan: 1 })
+    new Promise((resolve) => {
+      strictEqual(negotiate(header, supportedEncodings), expected)
+      resolve()
+    })
   })
 }


### PR DESCRIPTION
#### Checklist

This PR migrates from `tap` to `node:test` and `c8`

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
