### PR TITLE
docs(readme): update ci badge syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @fastify/accept-negotiator
 
 
-[![CI](https://github.com/fastify/accept-negotiator/workflows/CI/badge.svg)](https://github.com/fastify/accept-negotiator/actions/workflows/ci.yml)
+[![CI](https://github.com/fastify/accept-negotiator/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/fastify/accept-negotiator/actions/workflows/ci.yml)
 [![NPM version](https://img.shields.io/npm/v/@fastify/accept-negotiator.svg?style=flat)](https://www.npmjs.com/package/@fastify/accept-negotiator)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 


### PR DESCRIPTION
Syntax has changed, see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge